### PR TITLE
refactor: unify userinstall and interactive-userinstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,6 @@ install: all
 	chmod 644 ${DESTDIR}${MANPREFIX}/man1/DINA.1
 
 userinstall:
-	# User-local install for scripts and configs
-	mkdir -p ${HOME}/.local/bin
-	cp -f scripts/* ${HOME}/.local/bin
-	chmod +x ${HOME}/.local/bin/*
-
-	mkdir -p ${HOME}/.config/sxhkd
-	cp -f sxhkd/sxhkdrc ${HOME}/.config/sxhkd/sxhkdrc
-
-interactive-userinstall:
 	# Run the interactive userinstall script
 	@echo "Running interactive setup..."
 	@if [ -x "${HOME}/.local/bin/interactive-userinstall" ]; then \
@@ -37,6 +28,9 @@ interactive-userinstall:
 	else \
 		./scripts/interactive-userinstall; \
 	fi
+
+# Keep this for backwards compatibility
+interactive-userinstall: userinstall
 
 uninstall:
 	rm -f ${PREFIX}/bin/DINA

--- a/README
+++ b/README
@@ -46,13 +46,12 @@ Build and install as root:
 
     make clean install
 
-Then install user configs as your user:
+Then setup user configs as your user:
 
     make userinstall
 
-For interactive setup:
-
-    make interactive-userinstall
+This will run the interactive setup to install scripts,
+configure keybindings, and set up preferred applications.
 
 Building Debian Packages:
 

--- a/README.md
+++ b/README.md
@@ -56,19 +56,16 @@ make
 sudo make install
 ```
 
-#### 2. Install user configs and scripts (as your user):
+#### 2. Setup user configs and scripts (as your user):
 
 ```sh
 make userinstall
 ```
 
-#### 3. Interactive Setup (optional)
-
-For an accessible, interactive setup that helps you configure your preferred applications:
-
-```sh
-make interactive-userinstall
-```
+This will run the interactive setup that:
+- Installs all utility scripts to your ~/.local/bin directory
+- Sets up sxhkd configuration for keyboard shortcuts
+- Detects and configures your preferred applications
 
 This will:
 - Detect installed browsers, file managers, and terminals

--- a/scripts/interactive-userinstall
+++ b/scripts/interactive-userinstall
@@ -185,6 +185,34 @@ def install_scripts():
         print_error(f"Failed to install scripts: {e}")
         return False
 
+def setup_sxhkd_config():
+    """Setup sxhkd configuration directory and copy default config"""
+    try:
+        # Create sxhkd config directory if needed
+        sxhkd_dir = os.path.expanduser("~/.config/sxhkd")
+        if not os.path.exists(sxhkd_dir):
+            os.makedirs(sxhkd_dir)
+            print_info(f"Created directory {sxhkd_dir}")
+            
+        # Get path to default sxhkdrc
+        script_dir = os.path.dirname(os.path.abspath(__file__))
+        dina_dir = os.path.dirname(script_dir)
+        source_config = os.path.join(dina_dir, "sxhkd", "sxhkdrc")
+        dest_config = os.path.join(sxhkd_dir, "sxhkdrc")
+        
+        # Copy default sxhkdrc if it doesn't exist or if user wants to reset
+        if os.path.exists(source_config):
+            if not os.path.exists(dest_config) or ask_yes_no("Reset sxhkd configuration to defaults?"):
+                shutil.copy2(source_config, dest_config)
+                print_success(f"Copied default sxhkd configuration to {dest_config}")
+        else:
+            print_warning("Could not find default sxhkd configuration")
+            
+        return True
+    except Exception as e:
+        print_error(f"Failed to setup sxhkd configuration: {e}")
+        return False
+
 def main():
     # Show welcome message
     print_header("DINA Interactive Setup")
@@ -196,6 +224,17 @@ def main():
     if not ask_yes_no("Continue with setup?"):
         print("Setup cancelled")
         return
+        
+    # Install scripts
+    print_header("Installing DINA Scripts")
+    if install_scripts():
+        print_success("All scripts installed to ~/.local/bin")
+    else:
+        print_warning("Some scripts may not have been installed correctly")
+    
+    # Setup sxhkd configuration
+    print_header("Setting up sxhkd configuration")
+    setup_sxhkd_config()
     
     # Discover applications
     print_info("Searching for installed applications...")


### PR DESCRIPTION
Merge the userinstall and interactive-userinstall Makefile targets
to eliminate duplication and improve the installation process:
- User-local script installation is now handled by interactive-userinstall
- Added new setup_sxhkd_config function to handle sxhkd config
- Updated documentation to reflect simplified installation steps

Signed-off-by: Aaron Hewitt <aaron.graham.hewitt@gmail.com>